### PR TITLE
image preview is downsampled and rotated

### DIFF
--- a/android/client/src/com/tweetlanes/android/view/BaseLaneActivity.java
+++ b/android/client/src/com/tweetlanes/android/view/BaseLaneActivity.java
@@ -1387,6 +1387,7 @@ public class BaseLaneActivity extends FragmentActivity implements
         mShareImagePath = imagePath;
         if (imagePath != null && mComposeTweetFragment != null) {
             mComposeTweetFragment.showCompose();
+            mComposeTweetFragment.setMediaFilePath(imagePath);
             // mComposeTweet.setMediaFilePath(imagePath);
         }
     }


### PR DESCRIPTION
Re-enabled the option to send an image to be shared through TweetLanes. The image is correctly rotated and out of memory issues should be resolved.
The bug with losing the image when changing the orientation is still there. That's a tricky one.
