### PR TITLE
fix for #39, correcting patch for #9

### DIFF
--- a/android/client/src/com/tweetlanes/android/view/TweetFeedItemView.java
+++ b/android/client/src/com/tweetlanes/android/view/TweetFeedItemView.java
@@ -579,12 +579,7 @@ public class TweetFeedItemView extends LinearLayout {
                 public boolean onDown(MotionEvent e) {
                     return true;
                 }
-            }) {
-    	
-    	public boolean onTouchEvent(MotionEvent event) {
-    		return super.onTouchEvent(event);
-    	};
-    };
+            });
 
     public TwitterStatus getTwitterStatus() {
         return mTwitterStatus;


### PR DESCRIPTION
Fixes the wrong long-press detection condition introduced in the patch for issue #9 that results on the Tweet details opening when pressing linked tweet content.
