### PR TITLE
Update Validator.java

### DIFF
--- a/android/libraries/SocialNetLib/src/com/twitter/Validator.java
+++ b/android/libraries/SocialNetLib/src/com/twitter/Validator.java
@@ -8,8 +8,8 @@ import java.text.Normalizer;
 public class Validator {
   public static final int MAX_TWEET_LENGTH = 140;
 
-  protected int shortUrlLength = 20;
-  protected int shortUrlLengthHttps = 21;
+  protected int shortUrlLength = 22;
+  protected int shortUrlLengthHttps = 23;
 
   private Extractor extractor = new Extractor();
 


### PR DESCRIPTION
The t.co URL shorter length needs to be increased as currently the hard coded values are shorter than the generated URLs returned by twitter causing the characters left count when composing a tweet to be incorrect and post failure notifications when trying to tweet.

Current values should be as detailed via the following api call:

https://dev.twitter.com/docs/api/1.1/get/help/configuration

A short term fix will be to increase the values in the following file
https://github.com/chrislacy/TweetLanes/blob/master/android/libraries/SocialNetLib/src/com/twitter/Validator.java - pull request: https://github.com/chrislacy/TweetLanes/pull/50

Long term is to use the api call and use the values returned by the api.

Also, to note, there needs to be an additional value for tweets with media, currently twitter returns URLs with 23 characters which is 1 more than the non-HTTPS URLs and the same as HTTPS URLs.

_sorry for the duplicates, never realised it would open an issue when I submitted the pull..._
