### PR TITLE
Fixed Issue #215 Show full URL in the tweet.

### DIFF
--- a/android/libraries/SocialNetLib/src/com/twitter/AutolinkEx.java
+++ b/android/libraries/SocialNetLib/src/com/twitter/AutolinkEx.java
@@ -237,8 +237,8 @@ public class AutolinkEx {
         CharSequence url = entity.getValue();
         CharSequence linkText = escapeHTML(url);
 
-        if (urlEntity != null && urlEntity.getDisplayURL() != null) {
-            linkText = urlEntity.getDisplayURL();
+        if (urlEntity != null && urlEntity.getExpandedURL() != null) {
+            linkText = urlEntity.getExpandedURL();
         } else if (entity.displayURL != null) {
             linkText = entity.displayURL;
         }


### PR DESCRIPTION
Used getExpandedURL instead of getDisplayURL

Signed-off-by: R4md4c ahmedibrahimkhali@gmail.com
