### PR TITLE
Changed profile filler text to placeholder text

### DIFF
--- a/android/libraries/TweetLanesCore/res/layout/profile.xml
+++ b/android/libraries/TweetLanesCore/res/layout/profile.xml
@@ -108,7 +108,7 @@
                 android:paddingRight="20dip"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="The person's bio goes here. It could be anywhere up to 160 characters in length, which is anywhere up to and including the length of this wordly, informative string"
+                android:text="Loading bio..."
                 android:linksClickable="true"
                 />
 

--- a/android/libraries/TweetLanesCore/res/layout/profile_adn.xml
+++ b/android/libraries/TweetLanesCore/res/layout/profile_adn.xml
@@ -117,7 +117,7 @@
                 android:paddingRight="20dip"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="The person's bio goes here. It could be anywhere up to 160 characters in length, which is anywhere up to and including the length of this wordly, informative string"
+                android:text="Loading bio..."
                 android:linksClickable="true"
                 />
 


### PR DESCRIPTION
On a slow network the filler text was showing up before being replaced by the person's bio.
