### PR TITLE
Fix for issue #285.

### DIFF
--- a/android/libraries/TweetLanesCore/src/com/tweetlanes/android/core/view/HomeActivity.java
+++ b/android/libraries/TweetLanesCore/src/com/tweetlanes/android/core/view/HomeActivity.java
@@ -225,6 +225,9 @@ public class HomeActivity extends BaseLaneActivity {
                         } catch (java.lang.IllegalArgumentException e) {
                             Toast.makeText(this, R.string.picture_attach_error,
                                     Toast.LENGTH_SHORT).show();
+                        } finally {
+                            cursor.close();
+                            cursor = null;
                         }
 
                         turnSoftKeyboardOff = false;


### PR DESCRIPTION
This change closes a leaked Cursor after sharing an image to TweetLanes and helps correct issue #285. 
There was also a mismatched id, [as you can see here](https://github.com/adneal/TweetLanes/compare/chrislacy:develop...sharefix#L0R167) and I improved the `mLaneFragmentHashMap` performance by switching to a `SpareArray`.
