### PR TITLE
Implementing ViewHolder pattern inside TweetFeedListAdapter and DirectMessageConversationListAdapter

### DIFF
--- a/android/libraries/TweetLanesCore/src/com/tweetlanes/android/core/view/DirectMessageFeedFragment.java
+++ b/android/libraries/TweetLanesCore/src/com/tweetlanes/android/core/view/DirectMessageFeedFragment.java
@@ -973,16 +973,25 @@ public class DirectMessageFeedFragment extends BaseLaneFragment {
             } else if (position == directMessageCount) {
                 resultView = getLoadMoreView();
             } else {
-                resultView = getDirectMessageFeedItemView(position);
+                resultView = getDirectMessageFeedItemView(convertView, position);
             }
 
             return resultView;
         }
 
+        View inflateNewDirectMessageItem() {
+        	View convertView = mInflater.inflate(
+                    R.layout.direct_message_feed_item_received, null);
+        	ViewHolder holder = new ViewHolder(convertView);
+        	holder.directMessageItemView = (DirectMessageItemView) convertView
+                    .findViewById(R.id.directMessageItem);
+        	convertView.setTag(R.id.directMessageItem, holder);
+        	return convertView;
+        }
         /*
          *
          */
-        View getDirectMessageFeedItemView(int position) {
+        View getDirectMessageFeedItemView(View convertView, int position) {
 
             TwitterDirectMessage directMessage = mCurrentViewDirectMessageConversion
                     .get(position);
@@ -997,11 +1006,18 @@ public class DirectMessageFeedFragment extends BaseLaneFragment {
                 // mInflater.inflate(R.layout.direct_message_feed_item_sent,
                 // null);
             }
-            View convertView = mInflater.inflate(
-                    R.layout.direct_message_feed_item_received, null);
-
-            DirectMessageItemView directMessageItemView = (DirectMessageItemView) convertView
-                    .findViewById(R.id.directMessageItem);
+            
+            ViewHolder holder = null;
+            if (convertView != null) {
+            	holder = (ViewHolder) convertView.getTag(R.id.directMessageItem);
+            	if (holder == null) {
+            		convertView = inflateNewDirectMessageItem();
+        			holder = (ViewHolder) convertView.getTag(R.id.directMessageItem);
+            	}
+            } else {
+            	convertView = inflateNewDirectMessageItem();
+            	holder = (ViewHolder) convertView.getTag(R.id.directMessageItem);
+            }
 
             DirectMessageItemViewCallbacks callbacks = new DirectMessageItemViewCallbacks() {
 
@@ -1028,9 +1044,9 @@ public class DirectMessageFeedFragment extends BaseLaneFragment {
 
             };
 
-            directMessageItemView.configure(getScreenName(), directMessage,
+            holder.directMessageItemView.configure(getScreenName(), directMessage,
                     position + 1, messageType, otherUserId != null, callbacks);
-            return directMessageItemView;
+            return holder.directMessageItemView;
         }
 
         /*
@@ -1055,6 +1071,12 @@ public class DirectMessageFeedFragment extends BaseLaneFragment {
             return loadMoreView;
         }
 
+        class ViewHolder {
+        	public DirectMessageItemView directMessageItemView;
+        	public ViewHolder(View convertView) {
+        		directMessageItemView = (DirectMessageItemView) convertView.findViewById(R.id.directMessageItem);
+        	}
+        }
         /**
          * Remember our context so we can use it when constructing views.
          */

--- a/android/libraries/TweetLanesCore/src/com/tweetlanes/android/core/view/TweetFeedFragment.java
+++ b/android/libraries/TweetLanesCore/src/com/tweetlanes/android/core/view/TweetFeedFragment.java
@@ -1846,22 +1846,41 @@ public final class TweetFeedFragment extends BaseLaneFragment {
             } else if (position == statusCount) {
                 resultView = getLoadMoreView();
             } else {
-                resultView = getTweetFeedView(position);
+                resultView = getTweetFeedView(convertView, position);
             }
 
             return resultView;
         }
 
+        View inflateNewTweetFeedItem() {
+        	View view = mInflater.inflate(R.layout.tweet_feed_item_received, null);
+			ViewHolder holder = new ViewHolder(view);
+			view.setTag(R.id.tweetFeedItem, holder);
+			return view;
+        }
+        
         /*
          *
          */
-        View getTweetFeedView(int position) {
-
-            View convertView = mInflater.inflate(R.layout.tweet_feed_item_received, null);
+        View getTweetFeedView(View convertView, int position) {
+        	ViewHolder holder = null;
+        	// Sometimes the convertView comes with type of "LoadMoreView"
+    		// so we check if it contains a holder or not, if not then we inflate
+        	// a new TweetFeedItem cell to replace the LoadMoreView cell.
+        	if (convertView != null) {
+        		holder = (ViewHolder) convertView.getTag(R.id.tweetFeedItem);
+        		if (holder == null) {
+        			convertView = inflateNewTweetFeedItem();
+        			holder = (ViewHolder) convertView.getTag(R.id.tweetFeedItem);
+        		}
+        	} else {
+              convertView = inflateNewTweetFeedItem();
+              holder = (ViewHolder) convertView.getTag(R.id.tweetFeedItem);
+        	}
 
             TwitterStatus item = getStatusFeed().getStatus(position, getBaseLaneActivity().mStatusesFilter);
 
-            TweetFeedItemView tweetFeedItemView = (TweetFeedItemView) convertView.findViewById(R.id.tweetFeedItem);
+            TweetFeedItemView tweetFeedItemView = holder.tweetFeedItemView;
 
             TweetFeedItemView.Callbacks callbacks = new TweetFeedItemView.Callbacks() {
 
@@ -1968,6 +1987,15 @@ public final class TweetFeedFragment extends BaseLaneFragment {
 
             loadMoreView.configure(mode);
             return loadMoreView;
+        }
+        
+        private class ViewHolder {
+        	public TweetFeedItemView tweetFeedItemView;
+        	public ViewHolder(View convertView) {
+        		if (convertView != null) {
+        			tweetFeedItemView = (TweetFeedItemView) convertView.findViewById(R.id.tweetFeedItem);
+        		}
+        	}
         }
 
         private final LayoutInflater mInflater;

--- a/android/libraries/TweetLanesCore/src/com/tweetlanes/android/core/view/TweetFeedItemView.java
+++ b/android/libraries/TweetLanesCore/src/com/tweetlanes/android/core/view/TweetFeedItemView.java
@@ -182,8 +182,10 @@ public class TweetFeedItemView extends LinearLayout {
                     text += " " + mContext.getString(R.string.via) + " " + mTwitterStatus.mSource;
                 }
                 tweetDetailsView.setText(text);
+                tweetDetailsView.setVisibility(VISIBLE);
             } else if (showRetweetCount && twitterStatus.mRetweetCount > 0) {
                 tweetDetailsView.setText(verb + " " + twitterStatus.mRetweetCount + " times.");
+                tweetDetailsView.setVisibility(VISIBLE);
             } else {
                 if (showTweetSource) {
                     tweetDetailsView.setText(mContext.getString(R.string.via) + " " + mTwitterStatus.mSource);
@@ -198,6 +200,7 @@ public class TweetFeedItemView extends LinearLayout {
         if (mConversationToggle != null) {
 
             if (twitterStatus.mInReplyToStatusId != null) {
+            	mConversationToggle.setVisibility(VISIBLE);
                 mConversationToggle.setOnClickListener(new OnClickListener() {
 
                     @Override
@@ -214,6 +217,10 @@ public class TweetFeedItemView extends LinearLayout {
                 }
             } else {
                 mConversationToggle.setVisibility(GONE);
+                if (mConversationView != null) {
+                	removeView(mConversationView);
+                	mConversationView = null;
+                }
             }
         }
 


### PR DESCRIPTION
Fixed the issue of retweet text and other widgets not shown in a reused cell.
