### PR TITLE
Remove In App Purchases listing on Play Store

### DIFF
--- a/android/client/AndroidManifest.xml
+++ b/android/client/AndroidManifest.xml
@@ -13,7 +13,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="com.android.vending.BILLING" />
 	<uses-feature android:name="android.permission.CAMERA" android:required="false" />
 
     <application

--- a/android/clientbeta/AndroidManifest.xml
+++ b/android/clientbeta/AndroidManifest.xml
@@ -13,7 +13,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="com.android.vending.BILLING" />
 	<uses-feature android:name="android.permission.CAMERA" android:required="false" />
 
     <application


### PR DESCRIPTION
On the Play Store, the app details show 'In-app purchases'.

I believe it's linked to the following line in the AndroidManifest.xml file in android/client/ and android/clientbeta

```
<uses-permission android:name="com.android.vending.BILLING" />
```

![device-2013-12-17-214800 copy](https://f.cloud.github.com/assets/307943/1768613/71baca66-6765-11e3-86ea-3d718033ef16.png)

Should these lines be removed to avoid any confusion? It's always best practice to require only services you need in android.
